### PR TITLE
improve post and collection update logic

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -912,6 +912,8 @@ pub struct PostUpdateOptional {
     pub public: Option<bool>,
     pub public_edit: Option<bool>,
     pub description: Option<String>,
+    pub edit_timestamp: DateTime<Utc>,
+    pub fk_edit_user: i64,
 }
 
 impl PostUpdateOptional {
@@ -971,6 +973,8 @@ pub struct PostCollectionUpdateOptional {
     pub public_edit: Option<bool>,
     pub poster_object_key: Option<String>,
     pub description: Option<String>,
+    pub edit_timestamp: DateTime<Utc>,
+    pub fk_edit_user: i64,
 }
 
 impl PostCollectionUpdateOptional {

--- a/src/post.rs
+++ b/src/post.rs
@@ -414,6 +414,7 @@ pub async fn load_post_collection_detailed(
         create_user,
         edit_user,
         creation_timestamp: post_collection.creation_timestamp,
+        edit_timestamp: post_collection.edit_timestamp,
         public: post_collection.public,
         public_edit: post_collection.public_edit,
         poster_object,

--- a/src/post/create.rs
+++ b/src/post/create.rs
@@ -452,6 +452,7 @@ pub async fn create_post_collection_handler(
                 create_user,
                 edit_user,
                 creation_timestamp: post_collection.creation_timestamp,
+                edit_timestamp: post_collection.edit_timestamp,
                 public: post_collection.public,
                 public_edit: post_collection.public_edit,
                 poster_object,

--- a/src/query.rs
+++ b/src/query.rs
@@ -521,6 +521,7 @@ pub struct PostCollectionDetailed {
     pub create_user: UserPublic,
     pub edit_user: UserPublic,
     pub creation_timestamp: DateTime<Utc>,
+    pub edit_timestamp: DateTime<Utc>,
     #[serde(rename = "is_public")]
     pub public: bool,
     pub public_edit: bool,
@@ -567,6 +568,7 @@ pub async fn get_post_collection_handler(
         create_user,
         edit_user,
         creation_timestamp: post_collection.creation_timestamp,
+        edit_timestamp: post_collection.edit_timestamp,
         public: post_collection.public,
         public_edit: post_collection.public_edit,
         poster_object,


### PR DESCRIPTION
- update edit_timestamp and fk_edit_user in the same update statement as other field updates
  - also ensures that those changes to these two fields are included in the returned updated post
- add missing field edit_timestamp to PostCollectionDetailed